### PR TITLE
Ubuntu bookworm

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,3 +9,4 @@ Date | Topic |
 05-24-2016 | [Plotting the distribution of keywords in a single text with R](https://github.com/YaleDHLab/lab-workshops/tree/master/greek-text-analysis/single-text)
 05-31-2016 | [Plotting the distributions of keywords in multiple texts with R](https://github.com/YaleDHLab/lab-workshops/tree/master/greek-text-analysis/multiple-texts)
 07-14-2016 | [Web scraping with Unix and Python](https://github.com/YaleDHLab/lab-workshops/tree/master/web-scraping)
+08-18-2016 | [Building a Bookworm on a Linux Server](https://github.com/YaleDHLab/lab-workshops/tree/master/bookworm)

--- a/bookworm/ReadMe.md
+++ b/bookworm/ReadMe.md
@@ -6,7 +6,7 @@ Bookworm is an open-source data visualization package that helps reveal trends i
 
 ## Getting Started with Amazon Web Services
 
-To get started, we will need access to a Linux server. To do so, we'll [register for an account](https://aws.amazon.com/free) with Amazon Web Services (AWS), which gives students one year of free services. After registering, you'll be able to create Linux servers with just a few mouse clicks by following this step-by-step guide to [creating an Ubuntu 14.04 m4.large instance](https://github.com/YaleDHLab/lab-workshops/wiki/Creating-an-EC2-Instance-on-AWS).
+To get started, we will need access to a Linux server. To do so, we'll [register for an account](https://aws.amazon.com/free) with Amazon Web Services (AWS), which gives students one year of free services. After registering, you'll be able to create Linux servers with just a few mouse clicks by following this step-by-step guide to [creating an Ubuntu 14.04 m4.large instance](https://github.com/YaleDHLab/lab-workshops/wiki/Creating-an-EC2-Instance-on-AWS). Please note that creating the large instances required to install a Bookworm does cost [~10 cents per hour](https://github.com/YaleDHLab/lab-workshops/wiki/Building-a-Bookworm-on-an-Ubuntu-14.04-EC2-Instance).
 
 ## Connecting to your AWS Instance
 
@@ -14,7 +14,7 @@ Once you have created an Ubuntu instance, the next step is to connect to the ser
 
 ## Building a Bookworm
 
-Finally, once you've connected to your EC2 instance, you'll be prepared to build a bookworm. You can do so by following this guide on [building a Bookworm on an EC2 instance](https://github.com/YaleDHLab/lab-workshops/wiki/Installing-Bookworm-on-an-Ubuntu-14.04-EC2-Instance).
+Finally, once you've connected to your EC2 instance, you'll be prepared to build a bookworm. You can do so by following this guide on [building a Bookworm on an EC2 instance](https://github.com/YaleDHLab/lab-workshops/wiki/Building-a-Bookworm-on-an-Ubuntu-14.04-EC2-Instance).
 
 ## Questions or Difficulties
 

--- a/bookworm/ReadMe.md
+++ b/bookworm/ReadMe.md
@@ -1,147 +1,22 @@
-# Setting up the connection to the Amazon Linux machine
-* Download the .pem (Mac) or .ppk (Windows) file from the Google Doc.
+# Introduction to Bookworm
 
+![bookworm screenshot](./images/federalist.png)
 
-## Macintosh
-* Open the Downloads folder and make sure that your web browswer has not suffixed .txt to the downloaded file; it should end in .pem
-* You can now use this file, together with some information on your web browser screen, to get a remote terminal on the newly-launched Amazon Linux instance.
-*  In your Terminal, type `cd Downloads`
-*  Type `chmod 600 dhlabbookworm.pem`
-*  Type `ssh -i dhlabookworm.pem ec2-user@` followed (without a space) by the IP number you see in the "Public IP" column on the Amazon web page. (If you lose track of that page, it's [here](https://console.aws.amazon.com/ec2/v2/home?region=us-east-1#Instances)
-* The entire command should look something like `ssh -i ~/.ssh/MyKeyPair.pem ec2-user@54.166.243.250`, with your own IP address instead.
+Bookworm is an open-source data visualization package that helps reveal trends in plaintext documents over time. The following guide will walk users through the steps required to create a Bookworm instance from source code on a Linux server. At the end of the guide, you should have an interactive web page that looks like the image above.
 
+## Getting Started with Amazon Web Services
 
-## Windows
-* General instructions for using Putty with Amazon are [here](http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/putty.html)
-* Launch Putty and connect using `ec2-user@` followed by your public IP# with no space.
-* In the left-hand panel, Connection > SSH > Auth > Private Key File for Authentication, browse to the key location.
+To get started, we will need access to a Linux server. To do so, we'll [register for an account](aws.amazon.com/free) with Amazon Web Services (AWS), which gives students one year of free services. After registering, you'll be able to create Linux servers with just a few mouse clicks by following this step-by-step guide to [creating an Ubuntu 14.04 m4.large instance](https://github.com/YaleDHLab/lab-workshops/wiki/Creating-an-EC2-Instance-on-AWS).
 
-# Connecting to the Amazon Linux machine
-* You will need to approve connecting to the machine for the first time; hit `y` for Yes.
-* Now you should see a Unix command prompt in front of you in the Terminal. We'll do some updates first:
-* `sudo yum update -y`
-* Next, we'll install a few pieces of software that Bookworm will need to run:
-* `sudo yum install -y git gcc gcc-c++ httpd24 php56 mysql55-server mysql55-devel php56-mysqlnd`
+## Connecting to your AWS Instance
 
+Once you have created an Ubuntu instance, the next step is to connect to the server. To do so, you can follow this guide on [connecting to an EC2 instance](https://github.com/YaleDHLab/lab-workshops/wiki/Connecting-to-an-EC2-Instance).
 
+## Building a Bookworm
 
-# Compiling Gnu Parallel
-* `wget http://ftp.gnu.org/gnu/parallel/parallel-latest.tar.bz2`
-* `tar -xvjf parallel*`
-* `cd parallel-20160722`
-* `./configure`
-* `make`
-* `sudo make install`
+Finally, once you've connected to your EC2 instance, you'll be prepared to build a bookworm. You can do so by following this guide on [building a Bookworm on an EC2 instance](https://github.com/YaleDHLab/lab-workshops/wiki/Installing-Bookworm-on-an-Ubuntu-14.04-EC2-Instance).
 
-# Running Web Server + Database
-* Now that all that software is installed, we'll need to turn on the web server and database (MySQL) so that they're available:
-* `sudo service httpd start`
-* `sudo service mysqld start`
-* (You'll see a bunch of informational messages about MySQL. You can ignore those for now; we'll return to this in a little bit.)
-* We'll also want to ensure that our web server and database start back up if the machine is ever rebooted. To do that,
-* `sudo chkconfig httpd on`
-* `sudo chkconfig mysqld on`
-* `cd ~/`
-* `git clone git://github.com/Bookworm-project/BookwormDB`
-* `cd BookwormDB`
-* `sudo python setup.py install`
+## Questions or Difficulties
 
-> Time Estimate: 8 mins.
+If you have any questions on the process of building a bookworm, or encounter any difficulties as you do so, please feel free to [open an issue](https://github.com/YaleDHLab/lab-workshops/issues) and we'll be happy to help!
 
-* `cd ..`
-* `git clone https://github.com/bmschmidt/congress_api.git`
-* `cd congress_api`
-* `python get_and_unzip_data.py`
-
-> Time Estimate: 46 secs.
-
-* `python congress_parser.py`
-
-> Time Estimate: 30 secs.
-
-* `mv jsoncatalog.txt ../BookwormDB`
-* `mv input.txt ../BookwormDB`
-* `mv field_descriptions.json ../BookwormDB`
-
-
-# MySQL Database Setup
-
-* `sudo mysql_secure_installation`
-* Your database doesn't have a root password yet, so just hit return when queried.
-* Answer Yes to "Set root password?"
-* For this temporary instance that has no important data, you can use 'bookwormpw' as a password.
-* Answer Yes to "Remove anonymous user?"
-* Answer Yes to "Disallow root login remotely?"
-* Answer Yes to "Remove test database?"
-* Answer Yes to "Reload privelege tables?"
-* Use 'bwadmin' as the name for the admin user.
-* Use 'bookwormpw' as the password for user bwadmin
-* Enter 'bookwormpw' again to confirm.
-
-# Bookworm Database Setup
-
-# Customizing MySQL Install
-
-* `sudo nano /etc/my.cnf` and insert the following lines at the end of the file:
-
-```
-[client]
-max_allowed_packet=1073741824
-user = bwadmin
-password = bookwormpw
-
-[mysqld]
-max_allowed_packet=1073741824
-myisam_sort_buffer_size = 512M
-read_rnd_buffer_size = 8M
-read_buffer_size = 4M
-max_heap_table_size = 1024M
-tmp_table_size = 1024M
-
-character_set_server = utf8
-query_cache_size = 128M
-query_cache_type = 1
-query_cache_limit = 2M
-
-bulk_insert_buffer_size = 512M
-myisam_max_sort_file_size = 1500G
-sort_buffer_size = 8M
-
-key_buffer_size=1500M
-```
-
-* `nano ~/.my.cnf` and insert the following lines:
-`[client]
-user = bwadmin
-password = bookwormpw`
-
-
-* `cd ../BookwormDB`
-* `bookworm config mysql`
-* Answer `/home/ec2-user` when it queries you for the home directory path.
-
-# Initializing a new project
-
-* `bookworm init`
-* You can leave the default name of the Bookworm, or change it to something like "Congressional Data"
-* The Client Password should be already set to `bookwormpw`, so you can hit return.
-* The Client Usernaame should already be set to `bwadmin`, so you can hit return.
-
-# Building the Bookworm
-> Time Estimate: 8 mins.
-
-* `bookworm build all`
-
-# Build the LineChart Web Interface
-* `sudo env "PATH=$PATH" bookworm build linechartGUI`
-* For some reason this directory ends up in the wrong place, so:
-* `sudo mv /var/www/CongressionalData/ /var/www/html/`
-* Now we need the back-end script that serves the data:
-* `sudo cp ~/BookwormDB/bookwormDB/bin/dbbindings.py /var/www/cgi-bin/`
-* FIXME: Python Egg Cache is set to a whacko value.
-* FIXME: Workaround: `sudo mkdir /var/www/.python-eggs`
-* FIXME `sudo chmod 777 /var/www/.python-eggs`
-
-# Transforming individual text files into input.txt
-
-`find * -type f -print  | while read file; do echo -n ${file%.txt} >>../input.txt; echo -ne '\t' >> ../input.txt; cat $file >> ../input.txt; echo '' >> ../input.txt; done`

--- a/bookworm/ReadMe.md
+++ b/bookworm/ReadMe.md
@@ -6,7 +6,7 @@ Bookworm is an open-source data visualization package that helps reveal trends i
 
 ## Getting Started with Amazon Web Services
 
-To get started, we will need access to a Linux server. To do so, we'll [register for an account](aws.amazon.com/free) with Amazon Web Services (AWS), which gives students one year of free services. After registering, you'll be able to create Linux servers with just a few mouse clicks by following this step-by-step guide to [creating an Ubuntu 14.04 m4.large instance](https://github.com/YaleDHLab/lab-workshops/wiki/Creating-an-EC2-Instance-on-AWS).
+To get started, we will need access to a Linux server. To do so, we'll [register for an account](https://aws.amazon.com/free) with Amazon Web Services (AWS), which gives students one year of free services. After registering, you'll be able to create Linux servers with just a few mouse clicks by following this step-by-step guide to [creating an Ubuntu 14.04 m4.large instance](https://github.com/YaleDHLab/lab-workshops/wiki/Creating-an-EC2-Instance-on-AWS).
 
 ## Connecting to your AWS Instance
 

--- a/bookworm/ReadMe.md
+++ b/bookworm/ReadMe.md
@@ -6,7 +6,7 @@ Bookworm is an open-source data visualization package that helps reveal trends i
 
 ## Getting Started with Amazon Web Services
 
-To get started, we will need access to a Linux server. To do so, we'll [register for an account](https://aws.amazon.com/free) with Amazon Web Services (AWS), which gives students one year of free services. After registering, you'll be able to create Linux servers with just a few mouse clicks by following this step-by-step guide to [creating an Ubuntu 14.04 m4.large instance](https://github.com/YaleDHLab/lab-workshops/wiki/Creating-an-EC2-Instance-on-AWS). Please note that creating the large instances required to install a Bookworm does cost [~10 cents per hour](https://github.com/YaleDHLab/lab-workshops/wiki/Building-a-Bookworm-on-an-Ubuntu-14.04-EC2-Instance).
+To get started, we will need access to a Linux server. To do so, we'll [register for an account](https://aws.amazon.com/free) with Amazon Web Services (AWS), which gives students one year of free services. After registering, you'll be able to create Linux servers with just a few mouse clicks by following this step-by-step guide to [creating an Ubuntu 14.04 m4.large instance](https://github.com/YaleDHLab/lab-workshops/wiki/Creating-an-EC2-Instance-on-AWS). Please note that creating the large instances required to install a Bookworm does cost [~10 cents per hour](https://aws.amazon.com/ec2/pricing/).
 
 ## Connecting to your AWS Instance
 

--- a/bookworm/utils/prepare_ubuntu_bookworm.sh
+++ b/bookworm/utils/prepare_ubuntu_bookworm.sh
@@ -1,0 +1,123 @@
+#!/bin/bash
+
+#
+echo
+echo "Set up the basics"
+echo
+
+sudo apt-get update -y
+sudo apt-get upgrade -y
+sudo apt-get dist-upgrade -y
+sudo apt-get install -y gcc
+sudo apt-get install -y build-essential python-dev libmysqlclient-dev
+sudo apt-get install -y parallel
+sudo apt-get install git -y
+
+#
+echo
+echo "Setting up a LAMP server on EC2"
+echo
+
+sudo apt-get install -y lamp-server^
+sudo mysql_secure_installation
+
+#
+echo
+echo "Install Python and Extensions"
+echo
+
+sudo apt-get install -y python-dev
+sudo apt-get install -y python-pip
+sudo pip install regex
+sudo pip install nltk
+sudo pip install numpy
+sudo pip install mysql-python
+sudo pip install python-dateutil
+
+#
+echo
+echo "Setting up MySQL User Accounts"
+echo
+echo "Type a name for a MySQL User with all writing priveleges, then hit [Enter]:"
+read keeper
+
+pass_not_set=true
+while [ $pass_not_set == true ]; do 
+  echo
+  echo "Type a password for [$keeper], then hit [Enter]:"
+  read -s keeperpass
+  echo
+  echo "Retype the password for [$keeper], then hit [Enter]:"
+  read -s keeperpass2
+  echo
+  if [ $keeperpass != $keeperpass2 ]
+    then
+      echo "The passwords typed were not the same."
+  fi
+  if [ $keeperpass == $keeperpass2 ]
+    then
+      pass_not_set=false
+  fi
+done
+
+
+echo
+echo "Type a name for a MySQL User with read only priveleges, then hit [Enter]:"
+read reader
+
+pass_not_set=true
+while [ $pass_not_set == true ]; do 
+  echo
+  echo "Type a password for [$reader], then hit [Enter]:"
+  read -s readerpass
+  echo
+  echo "Retype the password for [$reader], then hit [Enter]:"
+  read -s readerpass2
+  echo
+  if [ $readerpass != $readerpass2 ]
+    then
+      echo "The passwords typed were not the same."
+  fi
+  if [ $readerpass == $readerpass2 ]
+    then
+      pass_not_set=false
+  fi
+done
+
+echo
+echo "Log into MySQL with your original root password:"
+
+mysql -u root -p --execute="CREATE USER '$keeper'@'127.0.0.1' IDENTIFIED BY '$keeperpass'; \
+  GRANT ALL PRIVILEGES ON *.* TO '$keeper'@'127.0.0.1' WITH GRANT OPTION; \
+  CREATE USER '$keeper'@'%' IDENTIFIED BY '$keeperpass'; \
+  GRANT ALL PRIVILEGES ON *.* TO '$keeper'@'%' WITH GRANT OPTION; \
+  CREATE USER 'admin'@'127.0.0.1'; \
+  GRANT RELOAD,PROCESS ON *.* TO 'admin'@'127.0.0.1'; \
+  CREATE USER '$reader'@'127.0.0.1' IDENTIFIED BY '$readerpass'; \
+  GRANT SELECT ON *.* TO '$reader'@'127.0.0.1' WITH GRANT OPTION; \
+  CREATE USER '$reader'@'%' IDENTIFIED BY '$readerpass'; \
+  GRANT SELECT ON *.* TO '$reader'@'%' WITH GRANT OPTION; \
+  GRANT SELECT ON *.* TO 'www-data'@'localhost'; \
+  GRANT SELECT ON *.* TO 'ubuntu'@'localhost'; \
+  FLUSH PRIVILEGES;"
+
+#
+echo
+echo "We will now create the MySQL .my.cnf file"
+echo
+
+
+# ****************************************************
+
+cd ~
+echo " " >> .my.cnf
+echo "#" >> .my.cnf
+echo "# The MySQL Database Server Configuration File" >> .my.cnf
+echo "#" >> .my.cnf
+echo " " >> .my.cnf
+echo "[client]" >> .my.cnf
+echo "user = $keeper" >> .my.cnf
+echo "password = $keeperpass" >> .my.cnf
+echo " " >> .my.cnf
+
+echo "All done!"


### PR DESCRIPTION
This branch moves documentation from the main README to three smaller wiki pages (to make each step more bite-sized), and changes the target OS from Amazon/CentOS to Ubuntu. We can document the Amazon flavor as well, but the Ubuntu is fairly painless and Trip had asked about it in particular, so I thought it was a good starter.

Closes #12 :)